### PR TITLE
build: allow to override KDIR and use currently running kernel as def…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 obj-m := i2c-gpio-param.o
-KDIR := /home/k/BUILD/RPI/linux/
+KDIR ?= /lib/modules/`uname -r`/build
 PWD := $(shell pwd)
 
 all:


### PR DESCRIPTION
…ault

Hi,

This PRt allows KDIR to be overritten with an environment variable and also
defaults its value to the currently running kernel. The latter was done to make
it more generic and the former is useful for build recipes that rely on
environmental variables (for example, packaging scripts).
